### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Syntaxes/Cap’n Proto.tmLanguage
+++ b/Syntaxes/Cap’n Proto.tmLanguage
@@ -55,13 +55,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(0x\h+|\d+(\.\d+)?)\b</string>
+			<string>\b(0x[0-9A-Fa-f]+|\d+(\.\d+)?)\b</string>
 			<key>name</key>
 			<string>constant.numeric.capnp</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>@0x\h+</string>
+			<string>@0x[0-9A-Fa-f]+</string>
 			<key>name</key>
 			<string>constant.numeric.unique-id.capnp</string>
 		</dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.